### PR TITLE
Bump Datastructures@0.19 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 AutoHashEquals = "0.2, 1.0, 2"
 ConstructionBase = "1.5"
-DataStructures = "0.19"
+DataStructures = "0.18, 0.19"
 DocStringExtensions = "0.8, 0.9"
 Logging = "<0.0.1, 1"
 PDDL = "0.2.17"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 AutoHashEquals = "0.2, 1.0, 2"
 ConstructionBase = "1.5"
-DataStructures = "0.18"
+DataStructures = "0.19"
 DocStringExtensions = "0.8, 0.9"
 Logging = "<0.0.1, 1"
 PDDL = "0.2.17"


### PR DESCRIPTION
Tests now log a number of deprecation warnings mainly related to `dequeue`/`enqueue` for `FastPriorityQueues`, but tests do pass.